### PR TITLE
Fixed some german translations. Changed statements from Raspberry Pi …

### DIFF
--- a/content/de/help/buttons-in-footer/index.md
+++ b/content/de/help/buttons-in-footer/index.md
@@ -27,7 +27,7 @@ Diese Funktion wird aktiviert, indem Sie die MoodleBox-Einstellungen in der Admi
 Nach dem Speichern der Änderungen werden die MoodleBox Neustart- und Ausschalten-Schaltflächen für Moodle-Rollen mit dem `tool/moodlebox:viewbuttonsinfooter` Recht angezeigt, das standardmäßig der Managerrolle und natürlich den Administratoren gewährt wird. Sie werden für andere Benutzer nicht angezeigt.
 
 {{< notice warning >}}
-Um das Risiko von Datenbeschädigungen auf der MicroSD-Karte zu minimieren, fahren Sie zuerst die MoodleBox manuell herunter, bevor Sie die Stromversorgung ausschalten.
+Um das Risiko von Datenbeschädigungen auf der microSD-Karte zu minimieren, fahren Sie zuerst die MoodleBox manuell herunter, bevor Sie die Stromversorgung ausschalten.
 {{< /notice >}}
 
  [1]: http://moodlebox.home/admin/settings.php?section=tool_moodlebox_settings

--- a/content/de/help/copy-the-disk-image.md
+++ b/content/de/help/copy-the-disk-image.md
@@ -1,5 +1,5 @@
 ---
-title: Disk-Image auf eine MicroSD-Karte kopieren
+title: Disk-Image auf eine microSD-Karte kopieren
 authors:
   - Nicolas Martignoni
   - Ralf Krause
@@ -15,13 +15,13 @@ categories:
 ---
 Haben Sie das [Disk-Image][1] heruntergeladen?
 
-Installieren Sie zuerst [balenaEtcher][2] (früher bekannt als _Etcher_) auf Ihrem Computer. Befolgen Sie dann die Anleitung für balenaEtcher, um das Disk-Image __{{< ghrelease user="moodlebox" repo="moodlebox" data="file_name" >}}__ auf Ihre MicroSD-Karte zu flashen.
+Installieren Sie zuerst [balenaEtcher][2] (früher bekannt als _Etcher_) auf Ihrem Computer. Befolgen Sie dann die Anleitung für balenaEtcher, um das Disk-Image __{{< ghrelease user="moodlebox" repo="moodlebox" data="file_name" >}}__ auf Ihre microSD-Karte zu flashen.
 
 {{< figure src="/img/media/etcher-copy.png" caption="Kopieren mit balenaEtcher" caption-position="bottom" caption-effect="appear" width="800px" >}}
 
 ### Für Experten
 
-Falls Sie es als Experte bevorzugen, zum Flashen der MicroSD-Karte einige Befehlszeilen ins Terminal einzugeben, geht dies auch. Extrahieren Sie die heruntergeladene Datei __{{< ghrelease user="moodlebox" repo="moodlebox" data="file_name" >}}__ und folgen Sie dann den [Anweisungen][3], um das Disk-Image __moodlebox-{{< ghrelease user="moodlebox" repo="moodlebox" data="version" >}}.img__ auf Ihre MicroSD-Karte zu kopieren.
+Falls Sie es als Experte bevorzugen, zum Flashen der microSD-Karte einige Befehlszeilen ins Terminal einzugeben, geht dies auch. Extrahieren Sie die heruntergeladene Datei __{{< ghrelease user="moodlebox" repo="moodlebox" data="file_name" >}}__ und folgen Sie dann den [Anweisungen][3], um das Disk-Image __moodlebox-{{< ghrelease user="moodlebox" repo="moodlebox" data="version" >}}.img__ auf Ihre microSD-Karte zu kopieren.
 
   * [Anleitung für macOS][4]
   * [Anleitung für Windows][5]

--- a/content/de/help/domain-name-change.md
+++ b/content/de/help/domain-name-change.md
@@ -1,11 +1,12 @@
 ---
-title: Änderung des Domainnamens der MoodleBox
+title: Domainnamen der MoodleBox ändern
 authors:
   - Nicolas Martignoni
+  - Ralf Krause
 type: kb
 date: 2018-09-27
-lastmod: 2020-01-06
-description: In diesem Leitfaden wird erklärt, wie Sie den Domänennamen Ihrer MoodleBox ändern können, dass er besser zu Ihrer eigenen lokalen Situation passt.
+lastmod: 2020-04-25
+description: In dieser Anleitung wird erklärt, wie Sie den Domainnamen Ihrer MoodleBox ändern können, damit er besser zu Ihrer lokalen Situation passt.
 slug: domainname-aenderung
 weight: 90
 categories:
@@ -13,17 +14,17 @@ categories:
 
 ---
 {{< notice warning >}}
-Die auf dieser Seite beschriebenen Vorgänge können __Ihre MoodleBox unbrauchbar machen__, was ein vollständiges Löschen der SD-Karte und den __Verlust aller Daten__ (Kursinhalte, installierte Plugins, benutzerdefinierte Konfigurationen, etc.) erfordert. Tun Sie dies nur, wenn Sie genau wissen, was Sie tun. In jedem Fall wird __keine Unterstützung__ zu diesem Thema geleistet.
+Die auf dieser Seite beschriebenen Vorgänge können __Ihre MoodleBox unbrauchbar machen__, was ein vollständiges Löschen der microSD-Karte und den __Verlust aller Daten__ (Kursinhalte, installierte Plugins, benutzerdefinierte Konfigurationen, usw.) erfordert. Tun Sie dies nur, wenn Sie wirklich genau wissen, was Sie tun. Bei Problemen wird __keine Unterstützung__ zu diesem Thema geleistet.
 
-Wir übernehmen keine Verantwortung für direkte oder indirekte Schäden, die durch die Nutzung der MoodleBox, insbesondere nach einem Domain-Namenwechsel, entstehen.
+Wir übernehmen keine Verantwortung für direkte oder indirekte Schäden, die durch die Nutzung der MoodleBox entstehen, insbesondere nach einer Änderung des Domainnamens.
 {{< /notice >}}
 
 ### Vorgehensweise
 
-Das folgende Beispiel zeigt, wie man den Domänennamen einer MoodleBox ändert, damit ein lokales Gerät sie mit einer neuen URL erreichen kann. Das Beispiel zeigt, wie man der MoodleBox den Domainnamen __learn.example.com__ gibt.
+Das Beispiel zeigt, wie man der MoodleBox den Domainnamen __learn.example.com__ gibt, damit ein lokales Endgerät die MoodleBox mit dieser neuen URL erreichen kann.
 
 {{< notice info >}}
-Dieser Vorgang hat keinen Einfluss auf den Zugriff auf die MoodleBox von einem Ethernet-Netzwerk oder vom Internet aus: Die MoodleBox __bleibt nur über das von ihr bereitgestellte WLAN-Netzwerk__, von den Geräten, die mit ihr verbunden sind, zugänglich.
+Dieser Vorgang hat keinen Einfluss auf den Zugriff auf die MoodleBox von einem Ethernet-Netzwerk oder vom Internet aus: Die MoodleBox __bleibt nur über das von ihr selber bereitgestellte WLAN-Netzwerk__ zugänglich.
 {{< /notice >}}
 
 #### Schritt 1: Änderung des Hostnamens (_Hostname_).
@@ -32,34 +33,34 @@ In der letzten Zeile der `/etc/hosts`-Datei, ersetzen Sie `moodlebox` durch `lea
 
 In der Datei `/etc/hostname` ersetzen Sie `moodlebox` durch `learn.example.com` (diese Änderung ist nicht notwendig, wird aber dringend empfohlen).
 
-#### Schritt 2: Anpassung der Konfiguration des nginx-Webservers
+#### Schritt 2: Anpassung des Webservers nginx
 
-Ändern Sie die Datei `/etc/nginx/sites-available/default` und ersetzen Sie `moodlebox` durch den vollständigen Domainnamen (_FQDN_) __learn.example.com__ in der `server_name` Direktive.
+Ändern Sie die Datei `/etc/nginx/sites-available/default` und ersetzen Sie `moodlebox` durch den vollständigen Domainnamen (_FQDN_) __learn.example.com__ in der Zuweisung `server_name`.
 
-#### Schritt 3: Anpassung der DHCP-Serverkonfiguration
+#### Schritt 3: Anpassung des DHCP-Servers
 
-Ändern Sie die Datei `/etc/dnsmasq.conf` und ersetzen Sie `home` durch __learn.example.com__ in den beiden Zeilen, die mit `domain` und `local` beginnen. Auskommentieren oder löschen Sie ganz die Zeile, die mit `address` beginnt.
+Ändern Sie die Datei `/etc/dnsmasq.conf` und ersetzen Sie `home` durch __learn.example.com__ in den beiden Zeilen, die mit `domain` und `local` beginnen. Auskommentieren oder löschen Sie die Zeile, die mit `address` beginnt.
 
 #### Schritt 4: Anpassung der Moodle-Konfiguration (Moodle-URL)
 
 Ersetzen Sie in der Datei `/var/wwww/moodle/config.php` in der Zeile, die mit `$CFG->wwwwroot` beginnt, die URL `http://moodlebox.home` durch `http://learn.example.com`. Fügen Sie keinen Schrägstrich am Ende der URL hinzu.
 
-#### Step 5: Neustart der MoodleBox durchführen
+#### Schritt 5: Neustart der MoodleBox
 
-Um diese Änderungen zu übernehmen, starten Sie Ihre MoodleBox neu.
+Um alle Änderungen zu übernehmen, starten Sie Ihre MoodleBox neu.
 
 #### Schritt 6: Ersetzen von Moodle-URLs
 
-Greifen Sie über Ihren Browser mit der neuen Adresse `http://learn.example.com/` auf Ihre MoodleBox zu und verwenden Sie das URL-Ersatz-Tool unter `http://learn.example.com/admin/tool/replace/index.php`, um URLs in der Moodle-Datenbank zu ersetzen.
+Rufen Sie mit Ihrem Browser die neue URL `http://learn.example.com/` auf und melden Sie sich als Administrator an. Verwenden Sie das Tool __Suchen und Ersetzen in der Datenbank__ `http://learn.example.com/admin/tool/replace/index.php`, um die URLs in der Moodle-Datenbank zu ersetzen.
 
-#### Step 7: SSL-Zertifikate ersetzen (optional)
+#### Schritt 7: SSL-Zertifikate ersetzen (optional)
 
-Wenn Sie [HTTPS][3] verwenden möchten, müssen Sie sich Ihre eigenen SSL-Zertifikate besorgen, da die von der MoodleBox bereitgestellten Zertifikate nicht mit Ihrem eigenen Domainnamen __learn.example.com__ funktionieren. Vergessen Sie nicht, auch die URL zu ändern.
+Wenn Sie [HTTPS][3] verwenden möchten, müssen Sie sich Ihre eigenen SSL-Zertifikate besorgen, da die von der MoodleBox bereitgestellten Zertifikate nicht mit dem neuen Domainnamen __learn.example.com__ funktionieren. Vergessen Sie nicht, auch die URL zu ändern.
 
 ### Ähnliche Möglichkeiten
 
 - [Den Namen des WLAN-Netzwerks ändern der MoodleBox][1].
-- Die MoodleBox zugänglich machen [über ein Ethernet-Kabelnetz][2].
+- Die MoodleBox zugänglich machen [über ein Ethernet-Netzwerk][2].
 
  [1]: {{< relref "help/wi-fi-configuration" >}}
  [2]: {{< relref "help/access-via-ethernet" >}}

--- a/content/de/help/download-the-disk-image.md
+++ b/content/de/help/download-the-disk-image.md
@@ -51,7 +51,8 @@ aliases:
   </div>
 </div>
 
-Folgen Sie nach dem Herunterladen des Disk-Images den Anweisungen für [Kopieren auf die microSD-Karte][1] und [Stelle deine MoodleBox][2] zur ersten Verwendung ein.
+
+Folgen Sie nach dem Herunterladen des Disk-Images den Anleitungen für das [Kopieren auf die microSD-Karte][1] und [Einschalten der MoodleBox][2] zur ersten Verwendung.
 
 Wenn Sie möchten, können Sie die [Entwicklung der MoodleBox unterstützen][3], indem Sie eine [freiwillige Spende machen][3].
 

--- a/content/de/help/hardware.md
+++ b/content/de/help/hardware.md
@@ -6,7 +6,7 @@ authors:
 type: kb
 date: 2017-04-20
 lastmod: 2020-02-26
-description: Hier ist eine Übersicht alle Dinge, die Sie für Ihre eigene MoodleBox brauchen
+description: Die Übersicht zeigt alle Dinge, die Sie für Ihre eigene MoodleBox brauchen
 slug: hardware-beschaffen
 weight: 3
 categories:
@@ -26,21 +26,21 @@ gallery_item:
     caption: Rapsberry Pi 3
 
 ---
-Hier ist eine Übersicht alle Dinge, die Sie für Ihre eigene MoodleBox brauchen:
+Die Übersicht zeigt alle Dinge, die Sie für Ihre eigene MoodleBox brauchen:
 
-  * Raspberry Pi [4 Model B][RPi4B], [3 Model B+][RPi3Bplus], [3 Model B][RPi3B] oder [3 Model A+][RPi3Aplus],
-  * Hochqualitatives [Stromversorgung][supply],
-  * [MicroSD-Karte][sdcard] von ausreichender Größe; wir empfehlen eine Größe von 32 GB oder mehr, obwohl MoodleBox mit einer kleineren Kartengröße funktionieren kann,
-  * [Gehäuse für Raspberry Pi][case] (nicht notwendig, aber Sie sollten den Raspberry Pi schützen).
+  * Raspberry Pi [4B][RPi4B], [3B+][RPi3Bplus], [3B][RPi3B] oder [3A+][RPi3Aplus],
+  * Hochwertige [Stromversorgung][supply],
+  * [microSD-Karte][sdcard] mit ausreichender Größe. Wir empfehlen eine Kartengröße von 32 GB oder mehr, auch wenn die MoodleBox mit einer kleineren Kartengröße funktioniert,
+  * [Gehäuse für Raspberry Pi][case] (nicht unbedingt notwendig, aber Sie sollten den Raspberry Pi schützen).
 
-Die Kosten für die gesamte Hardware betragen ungefähr 80€, USD 90 oder CHF 90.
+Die Gesamtkosten für die Hardware betragen ungefähr 80€, USD 90 oder CHF 90.
 
 {{< gallery >}}
 
 {{< notice tip >}}
-Der Erwerb einer __hochqualitativen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
+Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Qualität, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microSD-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -48,5 +48,5 @@ Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/ras
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/de/help/hardware.md
+++ b/content/de/help/hardware.md
@@ -40,7 +40,7 @@ Die Gesamtkosten für die Hardware betragen ungefähr 80€, USD 90 oder CHF 90.
 {{< notice tip >}}
 Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Qualität, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Qualität, z.B. [von Wirecutter empfohlen](https://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/

--- a/content/de/help/hardware.md
+++ b/content/de/help/hardware.md
@@ -40,7 +40,7 @@ Die Gesamtkosten für die Hardware betragen ungefähr 80€, USD 90 oder CHF 90.
 {{< notice tip >}}
 Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Qualität, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microSD-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Qualität, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -48,5 +48,5 @@ Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/ras
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/de/help/info-moodlebox/index.md
+++ b/content/de/help/info-moodlebox/index.md
@@ -30,7 +30,7 @@ Das Dashboard ermöglicht es Ihnen auch, die folgenden Aktionen durchzuführen.
 - [Neustart oder Herunterfahren][5] der MoodleBox
 
 {{< notice note >}}
-Wenn die Stromversorgung der MoodleBox nicht ausreichend ist, wird __oben auf jeder Seite eine Warnung__ angezeigt. Diese Warnung ist nur für den Administrator sichtbar. Andere MoodleBox-Benutzer sehen es nicht.
+Wenn die Stromversorgung der MoodleBox nicht ausreichend ist, wird __oben auf jeder Seite eine Warnung__ angezeigt. Diese Warnung ist nur für den Administrator sichtbar. Andere MoodleBox-Nutzer sehen diese Warnung nicht.
 {{< figure src="undervoltage.png" width="700" title="Nicht ausreichende Stromversorgung Warnung" class="centered-image" >}}
 {{< /notice >}}
 

--- a/content/de/help/install-the-moodlebox.md
+++ b/content/de/help/install-the-moodlebox.md
@@ -5,8 +5,8 @@ authors:
   - Ralf Krause
 type: kb
 date: 2017-09-15
-lastmod: 2019-10-30
-description: Diese Vorgehensweise ist notwendig, um die MoodleBox für die erste Verwendung zu installieren
+lastmod: 2020-04-25
+description: Diese Schritte sind notwendig, um die MoodleBox für die erste Verwendung zu installieren
 slug: moodlebox-installieren
 weight: 1
 categories:
@@ -19,25 +19,25 @@ Die folgende Vorgehensweise ist notwendig, um die MoodleBox für die erste Verwe
 
 ### Schritt 1: Hardware kaufen
 
-Die [Sachen, die Sie für Ihre MoodleBox benötigen][1], sind im Wesentlichen ein Raspberry Pi Model 3A, 3B, 3B+ oder 4B, ein Netzteil und eine MicroSD-Karte. [Weitere Informationen][1].
+Die [Dinge, die Sie für Ihre MoodleBox benötigen][1], sind im Wesentlichen ein Raspberry Pi 3A, 3B, 3B+ oder 4B, ein geeignetes Netzteil und eine microSD-Karte. [Weitere Infos zur Hardware][1].
 
 {{< notice tip >}}
-Der Erwerb einer __hochqualitativen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
+Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microSD-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
 ### Schritt 2: MoodleBox Disk-Image herunterladen
 
 Laden Sie das aktuelle [MoodleBox Disk-Image][2] aus dem Internet herunter und speichern Sie es auf Ihrer Festplatte.
 
-### Schritt 3: Disk-Image auf eine MicroSD-Karte kopieren
+### Schritt 3: Disk-Image auf eine microSD-Karte kopieren
 
 Für diese Aufgabe empfehlen wir Ihnen vorzugsweise [balenaEtcher][10]. [Weitere Informationen][3].
 
 ### Schritt 4: MoodleBox starten
 
-Setzen Sie die kopierte MicroSD-Karte in den Steckplatz im Raspberry Pi 3 ein. Schalten Sie die Stromversorgung ein. Die rote LED leuchtet und nach einigen Sekunden beginnt die grüne LED zu blinken. Auf Wunsch verbinden Sie die MoodleBox mit dem Netzwerk oder einem Internetrouter über ein Ethernet-Kabel, damit angeschlossene Geräte auf das Internet zugreifen können.
+Setzen Sie die kopierte microSD-Karte in den Steckplatz im Raspberry Pi ein. Schalten Sie die Stromversorgung ein. Die rote LED leuchtet und nach einigen Sekunden beginnt die grüne LED zu blinken. Auf Wunsch verbinden Sie die MoodleBox mit dem Netzwerk oder einem Internetrouter über ein Ethernet-Kabel, damit angeschlossene Geräte auf das Internet zugreifen können.
 
 Es sind keine weiteren Einstellungen notwendig. Sofort nach dem Start ist die MoodleBox fertig und voll funktionsfähig.
 
@@ -45,12 +45,12 @@ Es sind keine weiteren Einstellungen notwendig. Sofort nach dem Start ist die Mo
 
   * [WLAN verbinden][5]
   * [Moodle öffnen][4]
-  * [Ändern des Hauptkennworts][11]
+  * [Hauptkennwort ändern][11]
   * [WLAN konfigurieren][6]
-  * [SSH Zugriff][7] auf die MoodleBox
+  * [Zugriff über SSH][7] auf die MoodleBox
   * [Projekt MoodleBox unterstützen][8]
 
-Weitere Informationen finden Sie, wenn Sie in unserer [Knowledge Base][9] stöbern.
+Weitere Informationen finden Sie, wenn Sie systematisch in unserer [Wissensbasis][9] stöbern.
 
  [1]: {{< relref "help/hardware" >}}
  [2]: {{< relref "help/download-the-disk-image" >}}

--- a/content/de/help/install-the-moodlebox.md
+++ b/content/de/help/install-the-moodlebox.md
@@ -24,7 +24,7 @@ Die [Dinge, die Sie für Ihre MoodleBox benötigen][1], sind im Wesentlichen ein
 {{< notice tip >}}
 Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](https://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
 ### Schritt 2: MoodleBox Disk-Image herunterladen

--- a/content/de/help/install-the-moodlebox.md
+++ b/content/de/help/install-the-moodlebox.md
@@ -24,7 +24,7 @@ Die [Dinge, die Sie für Ihre MoodleBox benötigen][1], sind im Wesentlichen ein
 {{< notice tip >}}
 Der Erwerb einer __hochwertigen__ microSD-Karte und einer geeigneten Stromversorgung sind für den störungsfreien Betrieb der MoodleBox __unerlässlich__.
 
-Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microSD-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
+Wir empfehlen das [offizielle Netzteil](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) der Raspberry Foundation und eine microSD-Karte mit geprüfter Leistung, z.B. [von Wirecutter empfohlen](http://thewirecutter.com/reviews/best-microsd-card/). Die Verwendung anderer Netzteile sowie von microSD-Karten aus zweifelhaften Quellen kann zu systematischen Störungen führen, für die __keine Unterstützung geleistet werden kann__.
 {{< /notice >}}
 
 ### Schritt 2: MoodleBox Disk-Image herunterladen

--- a/content/de/help/internet-connection/index.md
+++ b/content/de/help/internet-connection/index.md
@@ -5,24 +5,24 @@ authors:
   - Ralf Krause
 type: kb
 date: 2017-04-20
-lastmod: 2020-02-08
-description: Diese Anleitung erklärt, wie man Nutzern, die über WLAN mit einer MoodleBox verbunden sind, eine Internetverbindung zur Verfügung stellt.
+lastmod: 2020-02-25
+description: Internetverbindung für Nutzer zur Verfügung stellen, die über WLAN mit einer MoodleBox verbunden sind.
 slug: internet-verbindung
 weight: 9
 categories:
   - Nutzung
 
 ---
-Es ist sehr einfach, Nutzern, die drahtlos mit einer MoodleBox verbunden sind, eine Internetverbindung zur Verfügung zu stellen.
+Es ist sehr einfach, eine Internetverbindung für Nutzer zur Verfügung zu stellen, die über WLAN mit der MoodleBox verbunden sind.
 
-Schließen Sie die MoodleBox einfach mit einem Ethernet-Kabel an ein Netzwerk mit Internetzugang an. Sobald die Verbindung verfügbar ist, haben die über das WLAN __MoodleBox__ verbundenen Geräte selbst Zugang zum Internet.
+Schließen Sie die MoodleBox mit einem Ethernet-Kabel an Ihren Router oder an ein Netzwerk mit Internetzugang an. Sobald die Verbindung verfügbar ist, haben alle über das WLAN __MoodleBox__ verbundenen Geräte selber Zugang zum Internet.
 
-Wenn Sie die MoodleBox jedoch __ohne Internetverbindung__ verwenden möchten, z.B. für Aktivitäten wie ein Escape Game oder Assessments, bei denen ein Internetzugang der Studierenden nicht erwünscht ist, trennen Sie einfach das Ethernet-Kabel von der MoodleBox. Ohne eine Ethernet-Kabelverbindung können über WLAN angeschlossene Geräte nur auf die auf der MoodleBox verfügbaren Ressourcen zugreifen.
+Wenn Sie die MoodleBox jedoch __ohne Internetverbindung__ verwenden möchten, z.B. für Aktivitäten wie ein Escape Game oder Assessments, bei denen ein Internetzugang der Nutzer nicht erwünscht ist, trennen Sie einfach das Ethernet-Kabel von der MoodleBox. Ohne eine Ethernet-Kabelverbindung können über WLAN angeschlossene Geräte nur auf die auf der MoodleBox verfügbaren Ressourcen zugreifen.
 
 {{< notice note >}}
-Ab Version 3.5.2 des MoodleBox-Images werden Informationen darüber, ob ein Ethernet-Kabel angeschlossen ist, auf dem [MoodleBox-Dashboard]({{{< relref "help/info-moodlebox" >}}) angezeigt.
+Ab Version 3.5.2 des MoodleBox-Images werden Informationen darüber, ob ein Ethernet-Kabel angeschlossen ist, auf dem [MoodleBox-Dashboard]({{< relref "help/info-moodlebox" >}}) angezeigt.
 
-Der Name der Interface, normalerweise `eth0`, sowie die IP-Adresse der MoodleBox, die über DHCP ermittelt wurde, und die Adresse des Default-Gateways werden ebenfalls angezeigt.
+Der Name der Schnittstelle, normalerweise `eth0`, die IP-Adresse der MoodleBox, die über DHCP zugewiesen wurde, und die IP-Adresse des Standard-Gateways werden angezeigt.
 {{< /notice >}}
 
 {{< figure src="ethernet-connexion.png" caption="Ethernet-Kabel angeschlossen" class="centered-image" width="700px" >}}

--- a/content/de/help/moodle-update.md
+++ b/content/de/help/moodle-update.md
@@ -1,27 +1,27 @@
 ---
-title: Moodle aktualisieren
+title: Wie wird Moodle aktualisiert
 authors:
   - Nicolas Martignoni
   - Ralf Krause
   - Adrian Perez Rodriguez
 type: kb
 date: 2018-02-13
-lastmod: 2020-02-18
-description: Möchten Sie Moodle auf der MoodleBox aktualisieren? Folgen Sie diese Anweisungen.
+lastmod: 2020-04-25
+description: Möchten Sie das Moodle auf der MoodleBox aktualisieren? Folgen Sie diese Anweisungen.
 slug: moodle-aktualisieren
 categories:
   - Wartung
 
 ---
 {{< notice warning >}}
-Bevor Sie Ihre Version von Moodle aktualisieren, stellen Sie sicher, dass die Serveranforderungen auf Ihrem MoodleBox erfüllt sind. Melden Sie sich dazu bei Moodle an, besuchen Sie [Website-Administration > Server > Serverkonfiguration](http://moodlebox.home/admin/environment.php), klicken Sie auf _Komponente aktualisieren_, dann überprüfen Sie, dass keine Zeile in rot _Prüfen_ sagt.
+Bevor Sie das Moodle auf Ihrer MoodleBox aktualisieren, stellen Sie sicher, dass die Serveranforderungen auf Ihrem MoodleBox erfüllt sind. Melden Sie sich dazu bei Moodle an, besuchen Sie [Website-Administration > Server > Serverkonfiguration](http://moodlebox.home/admin/environment.php), klicken Sie auf _Komponente aktualisieren_ und überprüfen Sie dann, dass keine Zeile in rot _Prüfen_ sagt.
 
-Warnungen _site nicht https_ und _php nicht 64 bit_ sind kein Problem und können ignoriert werden.
+Die Warnungen _site not https_ und _php not 64 bits_ sind kein Problem und können ignoriert werden.
 {{< /notice >}}
 
 Für eine Aktualisierung führen Sie folgende Anweisungen über die Kommandozeile im Terminal aus.
 
-Erstens [verbinden Sie sich mit der MoodleBox über SSH][2] und geben Sie Ihr Kennwort ein. Falls Sie [das Kennwort noch nicht geändert][3] haben, müssen sie natürlich [das standardmäßige Kennwort][4] __Moodlebox4$__ eingeben.
+Zuerst [verbinden Sie sich mit der MoodleBox über SSH][2] und geben Sie Ihr Kennwort ein. Falls Sie [das Kennwort noch nicht geändert][3] haben, müssen sie natürlich [das standardmäßige Kennwort][4] __Moodlebox4$__ eingeben.
 
 ```bash
 ssh moodlebox@moodlebox.home
@@ -36,7 +36,7 @@ cd /var/www/moodle/
 sudo -u moodlebox -g www-data git pull
 ```
 
-Öffnen Sie anschließend im Browser die URL http://moodlebox.home/admin/ und folgen Sie der Anleitung wie für jede beliebige Moodle-Installation. ([Weitere Infos in der Dokumentation][update]).
+Öffnen Sie anschließend im Browser die URL http://moodlebox.home/admin/ und folgen Sie der Anleitung wie für jede andere Moodle-Installation. ([Weitere Infos finden Sie in der Dokumentation][update]).
 
 ### Aktualisierung auf eine _Major_ Version (großer Versionssprung)
 
@@ -45,10 +45,10 @@ Um mit Ihrem Moodle auf die nächste __Major Version__ (3.9, 4.0, usw.) zu gelan
 ```bash
 sudo -u moodlebox -g www-data git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 sudo -u moodlebox -g www-data git fetch origin
-sudo -u moodlebox -g www-data git checkout MOODLE_38_STABLE
+sudo -u moodlebox -g www-data git checkout MOODLE_39_STABLE
 ```
 
-Öffnen Sie auch hier die URL http://moodlebox.home/admin und folgen Sie der Anleitung wie für jede beliebige Moodle-Installation. ([Weitere Infos in der Dokumentation][update]).
+Öffnen Sie auch hier im Browser die URL http://moodlebox.home/admin und folgen Sie der Anleitung wie für jede andere Moodle-Installation. ([Weitere Infos finden Sie in der Dokumentation][update]).
 
 {{< notice tip >}}
 Wenn Sie eine MoodleBox Version 2.5.0 und früher haben, verwenden Sie `sudo -u www-data git ...` anstelle von `sudo -u moodlebox -g www-data git ...` in den oben angegebenen Anweisungen.

--- a/content/de/help/startup-shutdown-restart.md
+++ b/content/de/help/startup-shutdown-restart.md
@@ -5,8 +5,8 @@ authors:
   - Ralf Krause
 type: kb
 date: 2017-04-20
-lastmod: 2018-08-19
-description: Wenn Sie wissen wollen, wie Sie Ihre MoodleBox richtig starten, stoppen oder neu starten können, finden Sie hier die gewünschten Informationen
+lastmod: 2020-04-25
+description: Informationen, wie Sie Ihre MoodleBox richtig starten, stoppen oder neu starten
 slug: einschalten-ausschalten-neustarten
 weight: 1
 categories:
@@ -14,35 +14,35 @@ categories:
   - Nutzung
 
 ---
-#### Einschalten
+### Einschalten
 
-Setzen Sie die kopierte MicroSD-Karte in den Steckplatz im Raspberry Pi 3 ein. Verbinden Sie die MoodleBox über ein Ethernet-Kabel mit dem Netzwerk oder dem Internetrouter. Schalten Sie die Stromversorgung ein. Die rote LED leuchtet und nach einigen Sekunden beginnt die grüne LED zu blinken.
+Setzen Sie die kopierte microSD-Karte in den Steckplatz im Raspberry Pi ein. Verbinden Sie die MoodleBox über ein Ethernet-Kabel mit dem Netzwerk oder dem Internetrouter. Schalten Sie die Stromversorgung ein. Die rote LED leuchtet und nach einigen Sekunden beginnt die grüne LED zu blinken.
 
 {{< figure src="/img/media/pi-plug-in.gif" caption="Einschalten" caption-position="bottom" caption-effect="appear" width="750px" >}}
 
 Es sind keine weiteren Einstellungen notwendig. Sofort nach dem Start ist die MoodleBox fertig und voll funktionsfähig.
 
-Falls es möglich ist, sollten Sie die MoodleBox bei jedem Start über Ethernet mit dem Netzwerk zu verbinden. Nur dann können die Wartungsaufgaben erfolgreich durchgeführt werden, die eine Internetverbindung erfordern (z.B. die Synchronisation der internen Systemuhr).
+Wenn es möglich ist, sollten Sie die MoodleBox bei jedem Start über Ethernet mit dem Netzwerk zu verbinden. Nur dann können die Systemaufgaben erfolgreich ablaufen, die eine Internetverbindung erfordern (z.B. die Synchronisation der internen Systemuhr).
 
-#### Ausschalten
-
-{{< notice warning >}}
-Um das Risiko von Datenbeschädigungen auf der MicroSD-Karte zu minimieren, fahren Sie zuerst die MoodleBox manuell herunter, bevor Sie die Stromversorgung ausschalten.
-{{< /notice >}}
+### Ausschalten
 
 Über die grafische Benutzeroberfläche können Sie die MoodleBox neu starten und sicher ausschalten.
 
-Melden Sie sich mit einem Administratorkonto in der Moodle-Plattform der MoodleBox an und rufen Sie die Einstellungsseite [Website-Administration > Server > MoodleBox] [1] auf.
+Melden Sie sich mit einem Administratorkonto in der Moodle-Plattform der MoodleBox an und rufen Sie die Einstellungsseite [Website-Administration > Server > MoodleBox][1] auf.
+
+{{< notice warning >}}
+Um das Risiko von Datenverlusten auf der microSD-Karte zu minimieren, fahren Sie bitte zuerst die MoodleBox manuell herunter, bevor Sie die Stromversorgung ausschalten.
+{{< /notice >}}
 
 {{< figure src="/img/media/restart-shutdown-de.png" caption="Neustarten und ausschalten" caption-position="bottom" caption-effect="appear" width="735px" >}}
 
-Im Abschnitt __Neustarten und ausschalten__ zeigt die Benutzeroberfläche zwei Schaltflächen, mit denen Sie die MoodleBox neustarten oder ausschalten können. Tippen Sie auf die Schaltfläche __MoodleBox ausschalten__, warten Sie einige Sekunden und kontrollieren Sie, dass die grüne LED nicht mehr leuchtet. Jetzt können Sie das Netzteil entfernen.
+Im Abschnitt __Neustarten und ausschalten__ zeigt die Benutzeroberfläche zwei Schaltflächen, mit denen Sie die MoodleBox neustarten oder ausschalten können. Tippen Sie auf die Schaltfläche __MoodleBox ausschalten__ und warten Sie dann einige Sekunden, bis die grüne LED nicht mehr leuchtet. Jetzt können Sie das Netzteil entfernen.
 
 ### Neustarten
 
-Melden Sie sich mit einem Administratorkonto in der Moodle-Plattform der MoodleBox an und rufen Sie die Einstellungsseite [Website-Administration > Server > MoodleBox] [1] auf.
+Melden Sie sich mit einem Administratorkonto in der Moodle-Plattform der MoodleBox an und rufen Sie die Einstellungsseite [Website-Administration > Server > MoodleBox][1] auf.
 
-Tippen Sie auf die Schaltfläche __MoodleBox neustarten__. Warten Sie einige Sekunden, bis die MoodleBox wieder verfügbar ist.
+Tippen Sie auf die Schaltfläche __MoodleBox neustarten__ und warten Sie einige Sekunden, bis die MoodleBox wieder verfügbar ist.
 
 ### Hardware zum Ein- und Ausschalten erweitern
 

--- a/content/de/help/upgrade-the-moodlebox.md
+++ b/content/de/help/upgrade-the-moodlebox.md
@@ -1,22 +1,22 @@
 ---
-title: Wie wird die MoodleBox aktualisiert
+title: Wie wird das Betriebssystem aktualisiert
 authors:
   - Nicolas Martignoni
   - Ralf Krause
 type: kb
 date: 2017-12-22
-lastmod: 2019-11-29
-description: Folgen Sie den Anweisungen unten, um Ihre MoodleBox regelmäßig zu aktualisieren
+lastmod: 2020-04-25
+description: Folgen Sie den folgenden Anweisungen, um Ihre MoodleBox regelmäßig zu aktualisieren
 slug: moodlebox-aktualisieren
 categories:
   - Wartung
 
 ---
-Als routinemäßige Sicherheitsmaßnahme wird empfohlen, die Serversoftware auf der MoodleBox regelmäßig zu aktualisieren. Mit dieser Maßnahme können mögliche Schwachstellen in der Raspbian-Distribution gepatcht und andere entdeckte Fehler behoben werden.
+Als routinemäßige Sicherheitsmaßnahme wird empfohlen, das Betriebssystem auf der MoodleBox in regelmäßigen Abständen zu aktualisieren. Mit dieser Maßnahme können mögliche Schwachstellen im Betriebssystem Raspbian gepatcht und andere entdeckte Fehler behoben werden.
 
 Für diese Operation muss die MoodleBox über ein Ethernetkabel mit dem Internet verbunden sein.
 
-### MoodleBox-Software aktualisieren
+### MoodleBox-Betriebssystem aktualisieren
 
   1. Melden Sie sich im Terminal über SSH für die [Eingabezeile der Moodlebox][1] an. Hier sind die [standardmäßigen Anmeldedaten][2].
   2. Verbinden Sie die MoodleBox über ein Ethernetkabel mit einem Internetrouter oder einem lokalen Netzwerk mit Internetzugang.
@@ -26,7 +26,7 @@ Für diese Operation muss die MoodleBox über ein Ethernetkabel mit dem Internet
       sudo apt-get update && sudo apt-get dist-upgrade -y
       ```
 
-  4. Die Verarbeitung dieser Anweisung wird wohl eine Weile dauern, wahrscheinlich mehrere Minuten. Die Dauer hängt vom Umfang der zu aktualisierenden Software, von der Bandbreite Ihrer Internetverbindung und von der Qualität Ihrer MicroSD-Karte ab.
+  4. Die Verarbeitung dieser Anweisung wird eine Weile dauern, wahrscheinlich mehrere Minuten. Die Dauer hängt vom Umfang der zu aktualisierenden Software, von der Bandbreite Ihrer Internetverbindung und von der Qualität Ihrer microSD-Karte ab.
   5. Am Ende des Update-Vorgangs geben Sie `exit` ein und bestätigen dies mit der Eingabetaste.
 
  [1]: {{< relref "help/command-line-access" >}}

--- a/content/de/news/version-270.md
+++ b/content/de/news/version-270.md
@@ -1,5 +1,5 @@
 ---
-title: Herausgabe der MoodleBox 2.7.0
+title: Veröffentlichung der MoodleBox 2.7.0
 description: MoodleBox 2.7.0 basiert auf Moodle 3.6.4+. Es erlaubt, die Neustart- und Ausschalten-Schaltflächen auf allen Moodle-Seiten anzuzeigen.
 date: 2019-05-20
 authors:
@@ -10,8 +10,8 @@ slug: version-2.7.0
 Die [Version 2.7.0][2] des [Disk-Image der MoodleBox][1] wurde heute veröffentlicht. Es bringt viele neue Funktionen mit sich.
 
   - Dieses Release basiert auf [Moodle][3] Version 3.6.4+.
-  - Sie basiert auf dem am 8. April 2019 veröffentlichten [Raspbian Stretch Lite Image][4].
-  - Eine neue Version des [MoodleBox Plugins für Moodle][5] ermöglicht es, die [Neustart- und Ausschalten-Schaltflächen][7] in die Fußzeile aller Moodle-Seiten anzuzeigen.
+  - Sie basiert auf dem am 8. April 2019 veröffentlichten [Raspbian Stretch Lite][4].
+  - Eine neue Version des [MoodleBox Plugins][5] ermöglicht es, die [Neustart- und Ausschalten-Schaltflächen][7] in die Fußzeile aller Moodle-Seiten anzuzeigen.
   - Eine Warnung wird dem Moodle-Administrator angezeigt, wenn das Netzteil der MoodleBox eine unzureichende Spannung liefert.
   - Ein [Captive Portal][6] ist in die MoodleBox integriert. Das Captive-Portal ist standardmäßig deaktiviert. [Lesen Sie die Dokumentation][6] für weitere Informationen.
   - Verschiedene Bugs wurden behoben.

--- a/content/de/news/version-360.md
+++ b/content/de/news/version-360.md
@@ -1,6 +1,6 @@
 ---
 title: "MoodleBox 3.6.0: Neues Dashboard mit IP-Adresse"
-description: MoodleBox 3.6.0 bietet ein umgestaltetes Dashboard, Moodle 3.8.1+ und Raspbian Lite vom 5. Februar 2020.
+description: MoodleBox 3.6.0 bietet ein überarbeitetes Dashboard, Moodle 3.8.1+ und aktualisiertes Raspbian Lite.
 date: 2020-02-12
 authors:
   - Nicolas Martignoni
@@ -12,8 +12,8 @@ Die [Version 3.6.0][2] des [Disk-Image der MoodleBox][1] wurde gerade veröffent
 
 {{< figure src="/img/media/dashboard.png" width="730" caption="Dashboard" class="centered-image" >}}
 
-  - Eine neue Version des [MoodleBox-Plugin für Moodle][Plugin] bietet ein überarbeitetes Dashboard, das unter anderem die IP-Adresse der MoodleBox und des Standard-Gateways anzeigt.
-  - Diese Version bietet [Moodle][moodle] Version 3.8.1+.
+  - Eine neue Version des [MoodleBox-Plugin für Moodle][Plugin] bietet ein überarbeitetes Dashboard, das jetzt auch die IP-Adresse der MoodleBox und die IP-Adresse des Standard-Gateways anzeigt.
+  - [Moodle][moodle] ist aktualisiert auf Version 3.8.1+.
   - [Raspbian Buster Lite][raspbian] ist aktualisiert auf die Version vom 5. Februar 2020.
   - Captive Portal Software [Nodogsplash][nds] ist auf die neueste Version aktualisiert.
   - [MathJax][mathjax] ist auf Version 2.7.7 aktualisiert.

--- a/content/en/help/hardware.md
+++ b/content/en/help/hardware.md
@@ -39,7 +39,7 @@ The total hardware amount is approximately USD 90, 80 € or CHF 90.
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -47,5 +47,5 @@ We recommend the [official Raspberry Foundation power supply](https://www.raspbe
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/en/help/hardware.md
+++ b/content/en/help/hardware.md
@@ -39,7 +39,7 @@ The total hardware amount is approximately USD 90, 80 € or CHF 90.
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](https://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/

--- a/content/en/help/hardware.md
+++ b/content/en/help/hardware.md
@@ -29,7 +29,7 @@ Here is the stuff you will need to build your MoodleBox:
 
   * Raspberry Pi [4 Model B][RPi4B], [3 Model B+][RPi3Bplus], [3 Model B][RPi3B] or [3 Model A+][RPi3Aplus],
   * High quality [Power supply][supply],
-  * [MicroSD card][sdcard] of sufficient size; we recommend a capacity of 32 GB or more, even if MoodleBox can work with a smaller card size,
+  * [microSD card][sdcard] of sufficient size; we recommend a capacity of 32 GB or more, even if MoodleBox can work with a smaller card size,
   * [Raspberry Pi case][case] (not essential, but very useful to protect the Raspberry Pi).
 
 The total hardware amount is approximately USD 90, 80 € or CHF 90.
@@ -39,7 +39,7 @@ The total hardware amount is approximately USD 90, 80 € or CHF 90.
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -47,5 +47,5 @@ We recommend the [official Raspberry Foundation power supply](https://www.raspbe
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/en/help/install-the-moodlebox.md
+++ b/content/en/help/install-the-moodlebox.md
@@ -23,7 +23,7 @@ The [stuff you will need][1] to build your MoodleBox is essentially a Raspberry 
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
 ### Step 2: Download the MoodleBox disk image

--- a/content/en/help/install-the-moodlebox.md
+++ b/content/en/help/install-the-moodlebox.md
@@ -23,7 +23,7 @@ The [stuff you will need][1] to build your MoodleBox is essentially a Raspberry 
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](https://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
 ### Step 2: Download the MoodleBox disk image

--- a/content/en/help/install-the-moodlebox.md
+++ b/content/en/help/install-the-moodlebox.md
@@ -18,25 +18,25 @@ This is the procedure to install the MoodleBox for its first utilisation.
 
 ### Step 1: Buy the hardware
 
-The [stuff you will need][1] to build your MoodleBox is essentially a Raspberry Pi Model 3A, 3B, 3B+ or 4B with a power supply and a MicroSD card. [More information here][1].
+The [stuff you will need][1] to build your MoodleBox is essentially a Raspberry Pi Model 3A, 3B, 3B+ or 4B with a power supply and a microSD card. [More information here][1].
 
 {{< notice tip >}}
 Selecting a __good quality__ microSD card and an adequate power supply are __essential__ for the proper operation of the MoodleBox.
 
-We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
+We recommend the [official Raspberry Foundation power supply](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) and a microSD card with tested performance, for example [those recommended by Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). The use of other power supplies, as well as microSD cards from dubious sources, can cause systematic malfunctions, for which __no support can be provided__.
 {{< /notice >}}
 
 ### Step 2: Download the MoodleBox disk image
 
 The [MoodleBox disk image][2] is available [here][2].
 
-### Step 3: Copy the disk image on your MicroSD card
+### Step 3: Copy the disk image on your microSD card
 
 For this operation, use preferably [balenaEtcher][10]. [More information here][3].
 
 ### Step 4: Startup your MoodleBox
 
-Insert your microSD card into the Raspberry Pi 3 slot and power it up. The red LED lights up, and after a few seconds the green LED lights up intermittently. If desired, connect the MoodleBox to the network or to an Internet router with an Ethernet cable to allow connected devices to access the Internet.
+Insert your microSD card into the Raspberry Pi slot and power it up. The red LED lights up, and after a few seconds the green LED lights up intermittently. If desired, connect the MoodleBox to the network or to an Internet router with an Ethernet cable to allow connected devices to access the Internet.
 
 There is no other manipulation to do: after the boot, your MoodleBox is ready and totally functional.
 

--- a/content/en/help/moodle-update.md
+++ b/content/en/help/moodle-update.md
@@ -43,7 +43,7 @@ To update to the next __major version__ of Moodle (3.9, 4.0, etc.), type the com
 ```bash
 sudo -u moodlebox -g www-data git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 sudo -u moodlebox -g www-data git fetch origin
-sudo -u moodlebox -g www-data git checkout MOODLE_38_STABLE
+sudo -u moodlebox -g www-data git checkout MOODLE_39_STABLE
 ```
 
 Then visit the URL http://moodlebox.home/admin and follow the update instructions, like any Moodle installation ([read the documentation][update]).

--- a/content/en/help/startup-shutdown-restart.md
+++ b/content/en/help/startup-shutdown-restart.md
@@ -15,7 +15,7 @@ categories:
 ---
 #### Startup
 
-Insert your microSD card into the Raspberry Pi 3 slot, power it up and connect it to the network via an Ethernet cable. The red LED lights up, and after a few seconds the green LED lights up intermittently.
+Insert your microSD card into the Raspberry Pi slot, power it up and connect it to the network via an Ethernet cable. The red LED lights up, and after a few seconds the green LED lights up intermittently.
 
 {{< figure src="/img/media/pi-plug-in.gif" caption="Startup" caption-position="bottom" caption-effect="appear" width="750px" >}}
 

--- a/content/fr/help/hardware.md
+++ b/content/fr/help/hardware.md
@@ -39,7 +39,7 @@ La totalité de l'investissement matériel nécessaire est d'environ 80 €, US
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](https://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/

--- a/content/fr/help/hardware.md
+++ b/content/fr/help/hardware.md
@@ -39,7 +39,7 @@ La totalité de l'investissement matériel nécessaire est d'environ 80 €, US
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -47,5 +47,5 @@ Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/produc
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/fr/help/hardware.md
+++ b/content/fr/help/hardware.md
@@ -39,7 +39,7 @@ La totalité de l'investissement matériel nécessaire est d'environ 80 €, US
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
  [RPi3Aplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-a-plus/
@@ -47,5 +47,5 @@ Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/produc
  [RPi3Bplus]: https://www.raspberrypi.org/products/raspberry-pi-3-model-b-plus/
  [RPi4B]: https://www.raspberrypi.org/products/raspberry-pi-4-model-b/
  [case]: https://www.raspberrypi.org/products/raspberry-pi-3-case/
- [sdcard]: https://thewirecutter.com/reviews/best-microSD-card/
+ [sdcard]: https://thewirecutter.com/reviews/best-microsd-card/
  [supply]: https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/

--- a/content/fr/help/install-the-moodlebox.md
+++ b/content/fr/help/install-the-moodlebox.md
@@ -23,7 +23,7 @@ Le [matériel nécessaire][1] pour faire votre MoodleBox consiste essentielleme
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](https://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
 

--- a/content/fr/help/install-the-moodlebox.md
+++ b/content/fr/help/install-the-moodlebox.md
@@ -18,12 +18,12 @@ Voici la procédure pour installer la MoodleBox en vue de sa première utilisati
 
 ### Étape 1 : acheter le matériel
 
-Le [matériel nécessaire][1] pour faire votre MoodleBox consiste essentiellement en une Raspberry Pi modèle 3A, 3B, 3B+ ou 4B avec une alimentation et une carte MicroSD. [Plus d'informations ici][1].
+Le [matériel nécessaire][1] pour faire votre MoodleBox consiste essentiellement en une Raspberry Pi modèle 3A, 3B, 3B+ ou 4B avec une alimentation et une carte microSD. [Plus d'informations ici][1].
 
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
 
@@ -31,13 +31,13 @@ Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/produc
 
 L'[image-disque][2] nécessaire pour construire la MoodleBox est [disponible ici][2].
 
-### Étape 3 : copier l'image-disque sur votre carte MicroSD
+### Étape 3 : copier l'image-disque sur votre carte microSD
 
 Pour cette opération, il est préférable d'utiliser [balenaEtcher][10]. [Plus d'informations ici][3].
 
 ### Étape 4 : démarrer votre MoodleBox
 
-Insérer dans la Raspberry Pi 3 la carte microSD (sur laquelle l'image-disque a été copiée) et brancher l'alimentation. La diode rouge s'allume, puis, après quelques secondes, la diode verte s'allume de façon intermittente. Si désiré, brancher la MoodleBox au réseau ou à un routeur Internet avec un câble ethernet afin de permettre aux appareils connectés d'accéder à Internet.
+Insérer dans la Raspberry Pi la carte microSD (sur laquelle l'image-disque a été copiée) et brancher l'alimentation. La diode rouge s'allume, puis, après quelques secondes, la diode verte s'allume de façon intermittente. Si désiré, brancher la MoodleBox au réseau ou à un routeur Internet avec un câble ethernet afin de permettre aux appareils connectés d'accéder à Internet.
 
 Il n'y a pas d'autre manipulation à effectuer : dès la fin de son démarrage, la MoodleBox est prête et fonctionnelle.
 

--- a/content/fr/help/install-the-moodlebox.md
+++ b/content/fr/help/install-the-moodlebox.md
@@ -23,7 +23,7 @@ Le [matériel nécessaire][1] pour faire votre MoodleBox consiste essentielleme
 {{< notice tip >}}
 Le choix d'une carte microSD de __bonne qualité__ ainsi que d'une alimentation électrique adéquate sont __essentiels__ pour le bon fonctionnement de la MoodleBox.
 
-Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microSD-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
+Nous recommandons l'[alimentation officielle](https://www.raspberrypi.org/products/raspberry-pi-universal-power-supply/) de la Fondation Raspberry et une carte microSD disposant de performances éprouvées, par exemple celles qui sont [recommandées par Wirecutter](http://thewirecutter.com/reviews/best-microsd-card/). L'utilisation d'autres alimentations, ainsi que de cartes microSD de provenances douteuses peuvent être en effet la cause de dysfonctionnements systématiques, pour lesquels __aucune assistance ne peut être assurée__.
 {{< /notice >}}
 
 

--- a/content/fr/help/moodle-update.md
+++ b/content/fr/help/moodle-update.md
@@ -43,7 +43,7 @@ Pour une mise à jour à une __version majeure__ de Moodle (3.9, 4.0, etc.), tap
 ```bash
 sudo -u moodlebox -g www-data git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 sudo -u moodlebox -g www-data git fetch origin
-sudo -u moodlebox -g www-data git checkout MOODLE_38_STABLE
+sudo -u moodlebox -g www-data git checkout MOODLE_39_STABLE
 ```
 
 Chargez ensuite dans le navigateur l'URL http://moodlebox.home/admin, et suivez les instructions de mise à jour, comme avec un Moodle standard ([voir la documentation][update]).

--- a/content/fr/help/startup-shutdown-restart.md
+++ b/content/fr/help/startup-shutdown-restart.md
@@ -15,7 +15,7 @@ categories:
 ---
 #### Démarrer la MoodleBox
 
-Insérer dans la Raspberry Pi 3 la carte microSD (sur laquelle l'image-disque a été copiée) et brancher l'alimentation ainsi qu'un câble ethernet pour la connexion au réseau. La diode rouge s'allume, puis, après quelques secondes, la diode verte s'allume de façon intermittente.
+Insérer dans la Raspberry Pi la carte microSD (sur laquelle l'image-disque a été copiée) et brancher l'alimentation ainsi qu'un câble ethernet pour la connexion au réseau. La diode rouge s'allume, puis, après quelques secondes, la diode verte s'allume de façon intermittente.
 
 {{< figure src="/img/media/pi-plug-in.gif" caption="Démarrage" caption-position="bottom" caption-effect="appear" width="750px" >}}
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -73,9 +73,9 @@
 - id: searchButton
   translation: "Suchen"
 - id: collapseArticles
-  translation: "Artikel einklappen"
+  translation: "Weniger anzeigen"
 - id: showAllArticles
-  translation: "Artikel ausklappen"
+  translation: "Mehr anzeigen"
 - id: error404
   translation: "Fehler 404 - Seite nicht gefunden"
 - id: error404Message


### PR DESCRIPTION
…3 to Raspberry Pi.

I fixed some german descriptions. I also changed some statements in the english and french versions because the instructions for the microSD card do not work only with the Raspberry Pi 3 but all Raspberry Pi versions.

I found that the linked power supply is wrong if you have a Raspberry Pi 4B. We should also change some pictures because currently the best device should be the Raspberry Pi 4B.

Best regards, Ralf