### PR TITLE
Fix carousel.js to support multiple list items

### DIFF
--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function() {
   carousels.forEach(function( carousel ) {
 
     const ele = carousel.querySelector('ul');
-    const scrolllength = carousel.querySelector('ul li:nth-child(2)').offsetLeft - carousel.querySelector('ul li:nth-child(1)').offsetLeft;
+    const scrolllength = carousel.querySelector('ul .item:nth-child(2)').offsetLeft - carousel.querySelector('ul .item:nth-child(1)').offsetLeft;
     const amountvisible = Math.round(ele.offsetWidth/scrolllength);
     const bullets = carousel.querySelectorAll('ol li');
     const nextarrow = carousel.querySelector('.next');


### PR DESCRIPTION
The carousel code fails when the 1st slide contains more than one list elements. 
This can be reproduced by updating the slogan.yaml:

```
weight: 1
title: "Moodle + Raspberry = MoodleBox"
description: >
  <ul class="list-style-none">
     <li>A small box on the table that brings Moodle to the entire classroom has a touch of magic!</li>
     <li>2nd line on 1st slide</li>
   </ul>
image: "/img/carousel/raspberry-pi-case.png"
```

This will raise a javascript runtime error:

```
carousel.js:16  Uncaught SyntaxError: Failed to execute 'querySelectorAll' on 'Element': 'ol li:nth-last-child(-n + -29)' is not a valid selector.
    at carousel.js:16:30
    at NodeList.forEach (<anonymous>)
    at HTMLDocument.<anonymous> (carousel.js:7:13)
	
```

The fix in this PR will correct the selection appropriate element, allowing the use of multiple list items on the 1st slide.
