### PR TITLE
Update language management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Download and setup Hugo
         uses: peaceiris/actions-hugo@v3
         env:
-          HUGO_RELEASE: '0.155.3'
+          HUGO_RELEASE: '0.158.0'
         with:
           hugo-version: ${{ env.HUGO_RELEASE }}
           extended: true

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -1,6 +1,6 @@
 en:
-  languageName: English
-  languageCode: en-us
+  label: English
+  locale: en-us
   contentDir: content/en
   weight: 1
   menu:
@@ -109,8 +109,8 @@ en:
       image: /img/media/elt.png
 
 fr:
-  languageName: Français
-  languageCode: fr-fr
+  label: Français
+  locale: fr-fr
   contentDir: content/fr
   weight: 2
   menu:
@@ -219,8 +219,8 @@ fr:
       image: /img/media/elt.png
 
 de:
-  languageName: Deutsch
-  languageCode: de-de
+  label: Deutsch
+  locale: de-de
   contentDir: content/de
   weight: 3
   menu:
@@ -329,8 +329,8 @@ de:
       image: /img/media/elt.png
 
 es:
-  languageName: Español
-  languageCode: es-es
+  label: Español
+  locale: es-es
   contentDir: content/es
   weight: 4
   menu:

--- a/layouts/_default/robots.txt
+++ b/layouts/_default/robots.txt
@@ -1,8 +1,6 @@
 User-agent: *
 
-Sitemap: {{ "sitemap.xml" | absURL -}}
-{{- if hugo.IsMultilingual }}
-{{ range site.Languages -}}
-  Sitemap: {{ printf "%s/sitemap.xml" .Lang | absURL }}
-{{ end }}
+Sitemap: {{ "sitemap.xml" | absURL }}
+{{ range hugo.Sites -}}
+  Sitemap: {{ .Home.Permalink }}sitemap.xml
 {{ end }}

--- a/layouts/partials/langswitcher.html
+++ b/layouts/partials/langswitcher.html
@@ -1,20 +1,12 @@
-{{ if hugo.IsMultilingual }}
+{{ with .Rotate "language" }}
 <li id="language-switch" class="dropdown">
-<a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-globe fa-lg" aria-hidden="true"></i> {{- .Language -}}</a>
+<a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-globe fa-lg" aria-hidden="true"></i> {{- $.Site.Language -}}</a>
 <ul class="dropdown-menu">
-  {{ $siteLanguages := site.Languages}}
-  {{ $pageLang := .Page.Lang}}
-  {{ range .Page.AllTranslations }}
-    {{ $translation := .}}
-    {{ range $siteLanguages }}
-      {{ if eq $translation.Lang .Lang }}
-        {{ $selected := false }}
-        {{ if eq $pageLang .Lang}}
-          <li><a href="{{ $translation.RelPermalink }}" class="active">{{ .LanguageName }}</a></li>
-        {{ else }}
-          <li><a href="{{ $translation.RelPermalink }}">{{ .LanguageName }}</a></li>
-        {{ end }}
-      {{ end }}
+  {{ range . }}
+    {{ if eq .Site.Language $.Site.Language }}
+      <li><a href="{{ .RelPermalink }}" class="active">{{ .Site.Language.Label }}</a></li>
+    {{ else }}
+      <li><a href="{{ .RelPermalink }}">{{ .Site.Language.Label }}</a></li>
     {{ end }}
   {{ end }}
 </ul>


### PR DESCRIPTION
Remove Site.Languages, deprecated since Hugo 0.156.0.